### PR TITLE
No longer returning swap fees

### DIFF
--- a/contracts/PoolState.sol
+++ b/contracts/PoolState.sol
@@ -26,14 +26,9 @@ contract PoolState {
     function getPoolInfo(address[][] calldata pools, uint length) external view returns (uint[] memory) {
         uint[] memory results = new uint[](length);
         uint count = 0;
-        // console.log("Length %s", length);
 
         for (uint i = 0; i < pools.length; i++) {
             address poolAddr = pools[i][0];
-
-            // console.log("Pool: %s", poolAddr);
-            results[count] = getUint(poolAddr, abi.encodeWithSignature("getSwapFee()"));
-            count++;
 
             for (uint j = 1; j < pools[i].length; j++) {
               address tokenAddr = pools[i][j];


### PR DESCRIPTION
PoolInfo returns both the swap fee and coin balances but we don't actually need the swap fee from this contract since it's calculated elsewhere.

This change means this contract now only returns balances which makes it single purpose.